### PR TITLE
Fixed collapsable lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,6 @@
                       id="collapseTwo"
                       class="collapse agenda-desc"
                       aria-labelledby="headingTwo"
-                      data-parent="#accordionTwo"
                     >
                       <p><span>Santiago Pastorino</span><span style="margin-left:10px">Time: 10:00</span></p>
                       <p>  </p>
@@ -243,7 +242,6 @@
                       id="collapseOne"
                       class="collapse agenda-desc"
                       aria-labelledby="headingOne"
-                      data-parent="#accordionTwo"
                     >
                       <p><span>Osvaldo Martin</span><span style="margin-left:10px">Time: 13:00</span></p>
                       <p>   </p>
@@ -267,7 +265,6 @@
                       id="collapseThree"
                       class="collapse agenda-desc"
                       aria-labelledby="headingThree"
-                      data-parent="#accordionTwo"
                     >
                       <p><span>To Be Announced</span><span style="margin-left:10px">Time: </span></p>
                       <p>To Be Announced </p>
@@ -291,25 +288,11 @@
                       id="collapseFour"
                       class="collapse agenda-desc"
                       aria-labelledby="headingFour"
-                      data-parent="#accordionTwo"
                     >
                       <p><span>To Be Announced</span><span style="margin-left:10px">Time: 09:30 PM</span></p>
                       <p>To Be Announced </p>
                     </div>
                   </div>
-                  <div>
-                    <button
-                      class="agenda-title"
-                      type="button"
-                      data-toggle="collapse"
-                      data-target="#collapseFive"
-                      aria-expanded="false"
-                      aria-controls="collapseFive"
-                    >
-
-<!--End Workshops Buttons-->
-
-              </div>
             </div>
           </div>
         </div>
@@ -331,9 +314,9 @@
                       class="agenda-title collapsed"
                       type="button"
                       data-toggle="collapse"
-                      data-target="#collapseOne"
-                      aria-expanded="true"
-                      aria-controls="collapseOne"
+                      data-target="#collapseFive"
+                      aria-expanded="false"
+                      aria-controls="collapseFive"
                     >
                     Keynote: Quoted Domain Specific Languages
                     <img class="float-right plus-icon" height="20" width="20" src="./images/add.svg" alt="Toggle">
@@ -341,86 +324,12 @@
                     </button>
 
                     <div
-                      id="collapseOne"
-                      class="collapse agenda-desc show"
+                      id="collapseFive"
+                      class="collapse agenda-desc"
                       aria-labelledby="headingOne"
-                      data-parent="#accordionOne"
                     >
                       <p><span>Phil Wadler</span><span style="margin-left:10px">Time: 09:40</span></p>
                       <p>A simple technique for building Domain-Specific Languages that developers can put to work today.</p>
-                    </div>
-                  </div>
-                  <div>
-                    <button
-                      class="agenda-title"
-                      type="button"
-                      data-toggle="collapse"
-                      data-target="#collapseFour"
-                      aria-expanded="false"
-                      aria-controls="collapseFour"
-                    >
-                    How to recognize good teaching practices using machine learning
-                    <img class="float-right plus-icon" height="20" width="20" src="./images/add.svg" alt="Toggle">
-		<img class="float-right minus-icon" height="20" width="20" src="./images/minus.svg" alt="Toggle">
-                    </button>
-
-                    <div
-                      id="collapseFour"
-                      class="collapse agenda-desc"
-                      aria-labelledby="headingFour"
-                      data-parent="#accordionOne"
-                    >
-                      <p><span>Karen Serfaty</span><span style="margin-left:10px">Time: 10:40</span></p>
-                      <p>How useful are the questions teachers ask their students? And how can we tell the difference with machine learning?</p>
-                    </div>
-                  </div>
-                  <div>
-                    <button
-                      class="agenda-title"
-                      type="button"
-                      data-toggle="collapse"
-                      data-target="#collapseThree"
-                      aria-expanded="false"
-                      aria-controls="collapseThree"
-                    >
-                    Probabilistic programming with PyMC and ArviZ
-                    <img class="float-right plus-icon" height="20" width="20" src="./images/add.svg" alt="Toggle">
-		<img class="float-right minus-icon" height="20" width="20" src="./images/minus.svg" alt="Toggle">
-                    </button>
-
-                    <div
-                      id="collapseThree"
-                      class="collapse agenda-desc"
-                      aria-labelledby="headingThree"
-                      data-parent="#accordionOne"
-                    >
-                      <p><span>Osvaldo Martin</span><span style="margin-left:10px">Time: 11:20</span></p>
-                      <p>      </p>
-                    </div>
-                  </div>
-
-                  <div>
-                    <button
-                      class="agenda-title"
-                      type="button"
-                      data-toggle="collapse"
-                      data-target="#collapseFive"
-                      aria-expanded="false"
-                      aria-controls="collapseFive"
-                    >
-                    Build web apps like it's 1972
-                    <img class="float-right plus-icon" height="20" width="20" src="./images/add.svg" alt="Toggle">
-		<img class="float-right minus-icon" height="20" width="20" src="./images/minus.svg" alt="Toggle">
-                    </button>
-
-                    <div
-                      id="collapseFive"
-                      class="collapse agenda-desc"
-                      aria-labelledby="headingFive"
-                      data-parent="#accordionOne"
-                    >
-                      <p><span>Leandro Ostera</span><span style="margin-left:10px">Time: 12:15</span></p>
-                      <p>Bringing back the Actor model</p>
                     </div>
                   </div>
                   <div>
@@ -432,15 +341,84 @@
                       aria-expanded="false"
                       aria-controls="collapseSix"
                     >
+                    How to recognize good teaching practices using machine learning
+                    <img class="float-right plus-icon" height="20" width="20" src="./images/add.svg" alt="Toggle">
+		<img class="float-right minus-icon" height="20" width="20" src="./images/minus.svg" alt="Toggle">
+                    </button>
+
+                    <div
+                      id="collapseSix"
+                      class="collapse agenda-desc"
+                      aria-labelledby="headingFour"
+                    >
+                      <p><span>Karen Serfaty</span><span style="margin-left:10px">Time: 10:40</span></p>
+                      <p>How useful are the questions teachers ask their students? And how can we tell the difference with machine learning?</p>
+                    </div>
+                  </div>
+                  <div>
+                    <button
+                      class="agenda-title"
+                      type="button"
+                      data-toggle="collapse"
+                      data-target="#collapseSeven"
+                      aria-expanded="false"
+                      aria-controls="collapseSeven"
+                    >
+                    Probabilistic programming with PyMC and ArviZ
+                    <img class="float-right plus-icon" height="20" width="20" src="./images/add.svg" alt="Toggle">
+		<img class="float-right minus-icon" height="20" width="20" src="./images/minus.svg" alt="Toggle">
+                    </button>
+
+                    <div
+                      id="collapseSeven"
+                      class="collapse agenda-desc"
+                      aria-labelledby="headingThree"
+                    >
+                      <p><span>Osvaldo Martin</span><span style="margin-left:10px">Time: 11:20</span></p>
+                      <p>      </p>
+                    </div>
+                  </div>
+
+                  <div>
+                    <button
+                      class="agenda-title"
+                      type="button"
+                      data-toggle="collapse"
+                      data-target="#collapseHeight"
+                      aria-expanded="false"
+                      aria-controls="collapseHeight"
+                    >
+                    Build web apps like it's 1972
+                    <img class="float-right plus-icon" height="20" width="20" src="./images/add.svg" alt="Toggle">
+		<img class="float-right minus-icon" height="20" width="20" src="./images/minus.svg" alt="Toggle">
+                    </button>
+
+                    <div
+                      id="collapseHeight"
+                      class="collapse agenda-desc"
+                      aria-labelledby="headingFive"
+                    >
+                      <p><span>Leandro Ostera</span><span style="margin-left:10px">Time: 12:15</span></p>
+                      <p>Bringing back the Actor model</p>
+                    </div>
+                  </div>
+                  <div>
+                    <button
+                      class="agenda-title"
+                      type="button"
+                      data-toggle="collapse"
+                      data-target="#collapseNine"
+                      aria-expanded="false"
+                      aria-controls="collapseNine"
+                    >
                     Lightning Talks
                     <img class="float-right plus-icon" height="20" width="20" src="./images/add.svg" alt="Toggle">
 		<img class="float-right minus-icon" height="20" width="20" src="./images/minus.svg" alt="Toggle">
                     </button>
                     <div
-                      id="collapseSix"
+                      id="collapseNine"
                       class="collapse agenda-desc"
                       aria-labelledby="headingSix"
-                      data-parent="#accordionOne"
                     >
                       <p><span>5-minute talks by various speakers</span><span style="margin-left:10px">Time: 14:30</span></p>
                       <p>"TL;DR event sourcing" and more to be announced</p>
@@ -451,9 +429,9 @@
                       class="agenda-title"
                       type="button"
                       data-toggle="collapse"
-                      data-target="#collapseSeven"
+                      data-target="#collapseTen"
                       aria-expanded="false"
-                      aria-controls="collapseSeven"
+                      aria-controls="collapseTen"
                     >
                     Why Rust?
                     <img class="float-right plus-icon" height="20" width="20" src="./images/add.svg" alt="Toggle">
@@ -461,10 +439,9 @@
                     </button>
 
                     <div
-                      id="collapseSeven"
+                      id="collapseTen"
                       class="collapse agenda-desc"
                       aria-labelledby="headingSeven"
-                      data-parent="#accordionOne"
                     >
                       <p><span>Santiago Pastorino</span><span style="margin-left:10px">Time: 15:05</span></p>
                       <p>¿Cómo tengo que preparar un set de datos para usar Machine Learning? ¿Cómo evalúo los diferentes modelos?</p>
@@ -475,9 +452,9 @@
                       class="agenda-title"
                       type="button"
                       data-toggle="collapse"
-                      data-target="#collapseSeven"
+                      data-target="#collapseEleven"
                       aria-expanded="false"
-                      aria-controls="collapseSeven"
+                      aria-controls="collapseEleven"
                     >
                     Desmitificando machine learning
                     <img class="float-right plus-icon" height="20" width="20" src="./images/add.svg" alt="Toggle">
@@ -485,10 +462,9 @@
                     </button>
 
                     <div
-                      id="collapseSeven"
+                      id="collapseEleven"
                       class="collapse agenda-desc"
                       aria-labelledby="headingSeven"
-                      data-parent="#accordionOne"
                     >
                       <p><span>Sebastian Waisbrot</span><span style="margin-left:10px">Time: 15:45</span></p>
                       <p>     </p>
@@ -499,9 +475,9 @@
                       class="agenda-title"
                       type="button"
                       data-toggle="collapse"
-                      data-target="#collapseSeven"
+                      data-target="#collapseTwelve"
                       aria-expanded="false"
-                      aria-controls="collapseSeven"
+                      aria-controls="collapseTwelve"
                     >
                     Keynote: Refactoring for Functional Programs
                     <img class="float-right plus-icon" height="20" width="20" src="./images/add.svg" alt="Toggle">
@@ -509,10 +485,9 @@
                     </button>
 
                     <div
-                      id="collapseSeven"
+                      id="collapseTwelve"
                       class="collapse agenda-desc"
                       aria-labelledby="headingSeven"
-                      data-parent="#accordionOne"
                     >
                       <p><span>Simon Thompson</span><span style="margin-left:10px">Time: 16:40</span></p>
                       <p>     </p>
@@ -523,9 +498,9 @@
                       class="agenda-title"
                       type="button"
                       data-toggle="collapse"
-                      data-target="#collapseSeven"
+                      data-target="#collapseThirteen"
                       aria-expanded="false"
-                      aria-controls="collapseSeven"
+                      aria-controls="collapseThirteen"
                     >
                     Keynote: A Lisp on NodeMCU: microcontroller dev without sacrificing interactivity
                     <img class="float-right plus-icon" height="20" width="20" src="./images/add.svg" alt="Toggle">
@@ -533,10 +508,9 @@
                     </button>
 
                     <div
-                      id="collapseSeven"
+                      id="collapseThirteen"
                       class="collapse agenda-desc"
                       aria-labelledby="headingSeven"
-                      data-parent="#accordionOne"
                     >
                       <p><span>Phil Hagelberg (A.K.A. Technomancy)</span><span style="margin-left:10px">Time: 17:40</span></p>
                       <p>     </p>
@@ -578,7 +552,6 @@
                       id="collapseOne"
                       class="collapse agenda-desc"
                       aria-labelledby="headingOne"
-                      data-parent="#accordionTwo"
                     >
                       <p><span>Santiago Picinini</span><span style="margin-left:10px">Time: 09:00</span></p>
                       <p>Usando software y hardware abierto para llevar internet a comunidades aisladas</p>
@@ -602,7 +575,6 @@
                       id="collapseTwo"
                       class="collapse agenda-desc"
                       aria-labelledby="headingTwo"
-                      data-parent="#accordionTwo"
                     >
                       <p><span>Santiago Tempone</span><span style="margin-left:10px">Time: 09:40</span></p>
                       <p>Communicating satellites through laser beams</p>
@@ -626,7 +598,6 @@
                       id="collapseThree"
                       class="collapse agenda-desc"
                       aria-labelledby="headingThree"
-                      data-parent="#accordionTwo"
                     >
                       <p><span>Francisco Albani</span><span style="margin-left:10px">Time: 10:20</span></p>
                       <p>Cómo diseñar una conexión con un satélite de órbitas bajas para bajar grandes volúmenes de datos</p>
@@ -650,7 +621,6 @@
                       id="collapseFour"
                       class="collapse agenda-desc"
                       aria-labelledby="headingFour"
-                      data-parent="#accordionTwo"
                     >
                       <p><span>Sebastián García Marra</span><span style="margin-left:10px">Time: 11:00</span></p>
                       <p>Estado del arte, desafíos y todo lo que siempre quisiste saber de trabajar con la Internet of Things</p>
@@ -674,7 +644,6 @@
                       id="collapseFive"
                       class="collapse agenda-desc"
                       aria-labelledby="headingFive"
-                      data-parent="#accordionTwo"
                     >
                       <p><span>Mariela Fiorenzo</span><span style="margin-left:10px">Time: 11:40</span></p>
                       <p>  </p>
@@ -698,7 +667,6 @@
                       id="collapseSix"
                       class="collapse agenda-desc"
                       aria-labelledby="headingSix"
-                      data-parent="#accordionTwo"
                     >
                       <p><span>Federico La Rocca</span><span style="margin-left:10px">Time: 12:20</span></p>
                       <p>  </p>
@@ -722,7 +690,6 @@
                       id="collapseSeven"
                       class="collapse agenda-desc"
                       aria-labelledby="headingSeven"
-                      data-parent="#accordionTwo"
                     >
                       <p><span>To Be Announced</span><span style="margin-left:10px">Time: 09:30 PM</span></p>
                       <p>To Be Announced </p>

--- a/styles.css
+++ b/styles.css
@@ -351,7 +351,7 @@ svg.icon.icon-right-arrow {
   background-image: url(./images/ufo.png?7d539baef6583c3aed7e55ca7c2b7e10);
   background-repeat: no-repeat;
   background-position: top left;
-  background-size: contain;
+  background-size: auto;
   margin-top: 74px;
 }
 
@@ -359,7 +359,7 @@ svg.icon.icon-right-arrow {
   background-image: url(./images/globe.png?da396c2baf9b6936b09bdf97ecf3bdf3);
   background-repeat: no-repeat;
   background-position: top right;
-  background-size: contain;
+  background-size: 23rem;
   margin-top: 160px;
 }
 


### PR DESCRIPTION
Había dos problemitas con los colapsables:
1. Algunos tenían id repetidos (entre los dos días), por lo que se veían afectados entre ellos.
2. Al abrir uno se colapsaba el resto, dejando los +/- como estaban. Hice que se mantuvieran abiertos si otro se clickea (me pareció mejor así para que no se vaya la info, en todo caso habría que dejar los data-parents como estaban y agregar una línea de js para cambiar el resto a +).